### PR TITLE
Remove Wasm Activation

### DIFF
--- a/ellaism.json
+++ b/ellaism.json
@@ -30,7 +30,6 @@
 		"eip155Transition": "0x0",
 		"eip98Transition": "0x7fffffffffffff",
 		"eip86Transition": "0x7fffffffffffff",
-		"wasmActivationTransition": 2000000,
 		"eip140Transition": 2000000,
 		"eip211Transition": 2000000,
 		"eip214Transition": 2000000,

--- a/shikinseki.json
+++ b/shikinseki.json
@@ -45,8 +45,7 @@
     "eip140Transition": 1234000,
     "eip211Transition": 1234000,
     "eip214Transition": 1234000,
-    "eip658Transition": 1234000,
-    "wasmActivationTransition": 1234000
+    "eip658Transition": 1234000
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
Tested full archive sync and checked all deployed contracts to confirm there were no deployed Wasm contracts.