### PR TITLE
Synchronize Chainspec with OpenEthereum

### DIFF
--- a/ellaism.json
+++ b/ellaism.json
@@ -28,8 +28,6 @@
 		"eip161abcTransition": "0x7fffffffffffffff",
 		"eip161dTransition": "0x7fffffffffffffff",
 		"eip155Transition": "0x0",
-		"eip98Transition": "0x7fffffffffffff",
-		"eip86Transition": "0x7fffffffffffff",
 		"eip140Transition": 2000000,
 		"eip211Transition": 2000000,
 		"eip214Transition": 2000000,
@@ -50,16 +48,18 @@
 		"gasLimit": "0x1388"
 	},
 	"nodes": [
-		"enode://0d88e242aa0b01ee306ca43e956174677c96ec8eba4197f4d8be6fd7d4f2e57731e95d533b88229b66eb1a44399d870e99b7a4fe6547c8c80cdf00407a986e14@94.130.237.158:30303",
-		"enode://4be9e419d3efb0214faf3ef1794a0c33ebbd7633ece734a0a956faa166fefc496b2692a2a485adc66af805e461ba3e12f8d3941ec207e56bb9f3d3626787a705@94.130.237.158:60606",
-		"enode://834246cc2a7584df29ccdcf3b5366f118a0e291264980376769e809665a02c4caf0d68c43eecf8390dbeaf861823b05583807af0a62542a1f3f717046b958a76@45.77.106.33:30303",
-		"enode://d8059dcb137cb52b8960ca82613eeba1d121105572decd8f1d3ea22b09070645eeab548d2a3cd2914f206e1331c7870bd2bd5a231ebac6b3d4886ec3b8e627e5@173.212.216.105:30303",
-		"enode://9215ad77bd081e35013cb42a8ceadff9d8e94a78fcc680dff1752a54e7484badff0904e331c4b40a68be593782e55acfd800f076d22f9d2832e8483733ade149@213.14.82.125:30303",
-		"enode://5dd35866da95aea15211fb1f98684f6e8c4e355e6aa3cc17585680ed53fa164477b8c52cb6ca4b24ec4d80f3d48ff9212b53feb131d825c7945a3abaaf02d24d@178.79.189.58:60606",
-		"enode://6c585c18024eb902ca093278af73b04863ac904caabc39ac2920c23532307c572ad92afd828a990c980d272b1f26307f2409cc97aec3ff9fe866732cae49a8c2@144.217.163.224:31337",
-		"enode://edd90c4cc64528802ad52fd127d80b641ff80fd43fa5292fb111c8bd2914482dffee288fd1b0d26440c6b2c669b10a53cbcd37c895ba0d6194110e100a965b2d@188.166.179.159:30303",
-		"enode://9d960373335c1cc38ca696dea8f2893e2a071c8f21524f21e8aae22be032acc3b67797b1d21e866f9d832943ae7d9555b8466c6ab34f473d21e547114952df37@213.32.53.183:30303",
-		"enode://5120308ebf25261c8423866a3a082e8d0f31106343d8b3b6c4dfe9d41bd900f5e03c64356ba51b6d343a951846a3f5ede5c5dd05925eaea4e4b9c35b1be9237c@95.53.247.188:30303"
+		"enode://b5e153bf33b2b77e6a09c1c3c20dbffc964b3622d53f25c1088fd5f4b88ec434af3c1ecea3318ad0cc3cdf48fad37dfec748ed6d9ebe271181d7e910fda7f340@142.93.163.95:30303",
+		"enode://a34e38cecf83bde932aca28f8a66487ef195ea9b253558d50dc3c5e3261909c7057ff102d3ba73bd3e887807a9fec42ec9f0c1c825263c1e4f8de0a5a4e857ed@157.245.181.78:30303",
+		"enode://2e9a4eaa046b45714ebb6052dee53c320b720e3ea5eee2cc0614d3dbeb19eb1a2e738491b46a3298c101fd6dd24b8b2e1b6e2c50a209e6c467f8b980ba1acf15@69.164.212.225:30303",
+		"enode://a7c84e5a44c6909ee4046a07101f2705b8cc0964d35c0f1b852e206dbbb787a5b6709ca3ba29d5df32ef431d06d14c1e0008bf1632415ba8b7b525cf80834723@176.99.9.182:30303",
+		"enode://4a383990e702b7ed4ec2eea42eebed3142905ddbba5c97865125d2e4b0f09990763f127e1781fc6357ae0578f4b6d322a92ce29b4e1704e2744a7ce9908e51e6@185.163.116.77:30303",
+		"enode://5fc0737f0cad2b9724edf8320878fc6e197b9968e5e9e798bbe24728c6e431858cb2ea4f8b151ee24bbc228820087db3c60fbde24b7d167896a25065f7dfb4c3@84.247.76.138:30303",
+		"enode://5364bd8aa566b79a4a9b88916f50b0140ea7ee1d4485394f60e09ba9c85927888dd7145b0a7d835663fc142ea44ce8f11405e34cb02d774e4edef94c634c570c@77.13.29.32:33003",
+		"enode://b9d6b7c82f9e8f6ba6c164da31cc2093dae3e1f1e1c315c71bd17a78b55a6f23e4d87b3ad0e3db6adaae4e561e7354b9d4d4be103b13f65e0638d7c5cdf48e4c@93.90.206.247:30303",
+		"enode://09284d2f3161e963168e3b69f6a83f27a129f30aa07a57bd8eafdccb66b9d653080721f4c3b51c2a119f113d1b9f9f736b14bbfcca7d2e2f9eb118c2e5ce3e81@83.219.143.198:30307",
+		"enode://93800f7367b4aba7a76d7a98fed44fa97cbcb62c6062bccdfad328e5786967c24f1f75c468e6a530425ec8839cac9c4b455b49ac5cdf37b6e67ba549439d285b@89.33.253.232:30303",
+		"enode://f15fcfb4e881d247b28db2ff7195ea380b642eda8601b646502cd31b827113c2f32ae9c98ac2673ce37a5df6ff1fdc737199c608a5defdd8b799e584461a4ba5@89.163.148.73:31058",
+		"enode://85d95b320452b745e45d4bb9353ad2eb180c98c9ffb85f9a572b972302f06dd2d130fa2ef723ac6cc6418eb842fd08fa5ad9d934288c756f9a63389bd354210e@18.228.30.92:21000"
 	],
 	"accounts": {
 		"0000000000000000000000000000000000000001": { "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
@@ -67,8 +67,47 @@
 		"0000000000000000000000000000000000000003": { "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
 		"0000000000000000000000000000000000000004": { "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
 		"0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": 2000000, "pricing": { "modexp": { "divisor": 20 } } } },
-		"0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": 2000000, "pricing": { "linear": { "base": 500, "word": 0 } } } },
-		"0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": 2000000, "pricing": { "linear": { "base": 40000, "word": 0 } } } },
-		"0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": 2000000, "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } }
+		"0000000000000000000000000000000000000006": {
+			"builtin": {
+				"name": "alt_bn128_add",
+				"pricing": {
+					"2000000": {
+						"price": { "alt_bn128_const_operations": { "price": 500 }}
+					},
+					"0x7fffffffffffff": {
+						"info": "EIP 1108 transition",
+						"price": { "alt_bn128_const_operations": { "price": 150 }}
+					}
+				}
+			}
+		},
+		"0000000000000000000000000000000000000007": {
+			"builtin": {
+				"name": "alt_bn128_mul",
+				"pricing": {
+					"2000000": {
+						"price": { "alt_bn128_const_operations": { "price": 40000 }}
+					},
+					"0x7fffffffffffff": {
+						"info": "EIP 1108 transition",
+						"price": { "alt_bn128_const_operations": { "price": 6000 }}
+					}
+				}
+			}
+		},
+		"0000000000000000000000000000000000000008": {
+			"builtin": {
+				"name": "alt_bn128_pairing",
+				"pricing": {
+					"2000000": {
+						"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
+					},
+					"0x7fffffffffffff": {
+						"info": "EIP 1108 transition",
+						"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This synchronizes our chainspec with OpenEtherem.

Removed the following deprecated/invalid transitions:
eip98Transition
eip86Transition

With these present, Parity 2+ and OpenEthereum throw an error:
> unknown field `eip86Transition`, expected one of `accountStartNonce`, `maximumExtraDataSize`, `minGasLimit`, `networkID`, `chainID`, `subprotocolName`, `forkBlock`, `forkCanonHash`, `eip150Transition`, `eip160Transition`, `eip161abcTransition`, `eip161dTransition`, `eip98Transition`, `eip155Transition`, `validateChainIdTransition`, `validateReceiptsTransition`, `eip140Transition`, `eip210Transition`, `eip210ContractAddress`, `eip210ContractCode`, `eip210ContractGas`, `eip211Transition`, `eip145Transition`, `eip214Transition`, `eip658Transition`, `eip1052Transition`, `eip1283Transition`, `eip1283DisableTransition`, `eip1283ReenableTransition`, `eip1014Transition`, `eip1706Transition`, `eip1344Transition`, `eip1884Transition`, `eip2028Transition`, `eip2200AdvanceTransition`, `dustProtectionTransition`, `nonceCapIncrement`, `removeDustContracts`, `gasLimitBoundDivisor`, `registrar`, `applyReward`, `nodePermissionContract`, `maxCodeSize`, `maxTransactionSize`, `maxCodeSizeTransition`, `transactionPermissionContract`, `transactionPermissionContractTransition`, `wasmActivationTransition`, `wasmVersion`, `kip4Transition`, `kip6Transition` at line 32 column 20

The rest of the changes are matching OpenEthereum.

